### PR TITLE
Avoid possible null reference exception on device connection failure

### DIFF
--- a/BrickController2/BrickController2/UI/ViewModels/DevicePageViewModel.cs
+++ b/BrickController2/BrickController2/UI/ViewModels/DevicePageViewModel.cs
@@ -140,7 +140,7 @@ namespace BrickController2.UI.ViewModels
                 false,
                 async (progressDialog, token) =>
                 {
-                    using (token.Register(() => _connectionTokenSource.Cancel()))
+                    using (token.Register(() => _connectionTokenSource?.Cancel()))
                     {
                         connectionResult = await Device.ConnectAsync(
                             _reconnect,


### PR DESCRIPTION
Unfortunately I have no steps-to-repro, but I met it once on Android BC2 app, several times in my Windows prototype which might be affected by different Bluetooth connection timing on Windows or any race condition in my UWP prototype. 