### PR TITLE
Show colored channel names in UI

### DIFF
--- a/BrickController2/BrickController2/DeviceManagement/BluetoothDevice.cs
+++ b/BrickController2/BrickController2/DeviceManagement/BluetoothDevice.cs
@@ -22,11 +22,16 @@ namespace BrickController2.DeviceManagement
             : base(name, address, deviceRepository)
         {
             _bleService = bleService;
+
+            // right now it's not expected to be changed
+            RegisterDefaultPorts();
         }
 
         protected abstract bool AutoConnectOnFirstConnect { get; }
         protected abstract Task<bool> ValidateServicesAsync(IEnumerable<IGattService> services, CancellationToken token);
         protected abstract Task ProcessOutputsAsync(CancellationToken token);
+
+        protected abstract void RegisterDefaultPorts();
 
         public async override Task<DeviceConnectionResult> ConnectAsync(
             bool reconnect,

--- a/BrickController2/BrickController2/DeviceManagement/BoostDevice.cs
+++ b/BrickController2/BrickController2/DeviceManagement/BoostDevice.cs
@@ -16,5 +16,16 @@ namespace BrickController2.DeviceManagement
 
         public override DeviceType DeviceType => DeviceType.Boost;
         public override int NumberOfChannels => 4;
+
+        protected override void RegisterDefaultPorts()
+        {
+            RegisterPorts(new[]
+            {
+                new DevicePort(0, "A"),
+                new DevicePort(1, "B"),
+                new DevicePort(2, "C"),
+                new DevicePort(3, "D"),
+            });
+        }
     }
 }

--- a/BrickController2/BrickController2/DeviceManagement/BuWizz2Device.cs
+++ b/BrickController2/BrickController2/DeviceManagement/BuWizz2Device.cs
@@ -60,6 +60,17 @@ namespace BrickController2.DeviceManagement
             _outputLevelValue = Math.Max(0, Math.Min(NumberOfOutputLevels - 1, value));
         }
 
+        protected override void RegisterDefaultPorts()
+        {
+            RegisterPorts(new[]
+            {
+                new DevicePort(0, "1"),
+                new DevicePort(1, "2"),
+                new DevicePort(2, "3"),
+                new DevicePort(3, "4"),
+            });
+        }
+
         protected override Task<bool> ValidateServicesAsync(IEnumerable<IGattService> services, CancellationToken token)
         {
             var service = services?.FirstOrDefault(s => s.Uuid == SERVICE_UUID);

--- a/BrickController2/BrickController2/DeviceManagement/BuwizzDevice.cs
+++ b/BrickController2/BrickController2/DeviceManagement/BuwizzDevice.cs
@@ -55,6 +55,17 @@ namespace BrickController2.DeviceManagement
             _outputLevelValue = Math.Max(0, Math.Min(NumberOfOutputLevels - 1, value));
         }
 
+        protected override void RegisterDefaultPorts()
+        {
+            RegisterPorts(new[]
+            {
+                new DevicePort(0, "1"),
+                new DevicePort(1, "2"),
+                new DevicePort(2, "3"),
+                new DevicePort(3, "4"),
+            });
+        }
+
         protected override Task<bool> ValidateServicesAsync(IEnumerable<IGattService> services, CancellationToken token)
         {
             var service = services?.FirstOrDefault(s => s.Uuid == SERVICE_UUID);

--- a/BrickController2/BrickController2/DeviceManagement/Device.cs
+++ b/BrickController2/BrickController2/DeviceManagement/Device.cs
@@ -1,6 +1,7 @@
 ﻿using BrickController2.Helpers;
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -10,6 +11,7 @@ namespace BrickController2.DeviceManagement
     {
         private readonly IDeviceRepository _deviceRepository;
         protected readonly AsyncLock _asyncLock = new AsyncLock();
+        private ObservableCollectionExt<DevicePort> _registeredPorts;
 
         private string _name;
         private string _firmwareVersion = "-";
@@ -22,6 +24,7 @@ namespace BrickController2.DeviceManagement
         internal Device(string name, string address, IDeviceRepository deviceRepository)
         {
             _deviceRepository = deviceRepository;
+            _registeredPorts = new ObservableCollectionExt<DevicePort>();
 
             _name = name;
             Address = address;
@@ -38,6 +41,8 @@ namespace BrickController2.DeviceManagement
             get { return _name; }
             set { _name = value; RaisePropertyChanged(); }
         }
+
+        public ObservableCollection<DevicePort> RegisteredPorts => _registeredPorts;
 
         public string FirmwareVersion
         {
@@ -122,6 +127,17 @@ namespace BrickController2.DeviceManagement
         protected float CutOutputValue(float outputValue)
         {
             return Math.Max(-1F, Math.Min(1F, outputValue));
+        }
+
+        /// <summary>
+        /// Apply the specified list of ports as currently registered.
+        /// </summary>
+        /// <param name="ports">List of ports</param>
+        protected void RegisterPorts(IList<DevicePort> ports)
+        {
+            if (ports == null) throw new ArgumentNullException(nameof(ports));
+
+            _registeredPorts.AddRange(ports);
         }
     }
 }

--- a/BrickController2/BrickController2/DeviceManagement/DevicePort.cs
+++ b/BrickController2/BrickController2/DeviceManagement/DevicePort.cs
@@ -1,0 +1,18 @@
+﻿namespace BrickController2.DeviceManagement
+{
+    /// <summary>
+    /// Represents immutable description of a device port
+    /// </summary>
+    public class DevicePort
+    {
+        public DevicePort(int channel, string name)
+        {
+            Channel = channel;
+            Name = name;
+        }
+
+        public int Channel { get; }
+
+        public string Name { get; }
+    }
+}

--- a/BrickController2/BrickController2/DeviceManagement/InfraredDevice.cs
+++ b/BrickController2/BrickController2/DeviceManagement/InfraredDevice.cs
@@ -13,6 +13,14 @@ namespace BrickController2.DeviceManagement
             : base(name, address, deviceRepository)
         {
             _infraredDeviceManager = infraredDeviceManager;
+
+            // setup default list of ports here as the list does not change
+            RegisterPorts(
+                new[]
+                {
+                    new DevicePort(0, "Blue"),
+                    new DevicePort(1, "Red"),
+                });
         }
 
         public override DeviceType DeviceType => DeviceType.Infrared;

--- a/BrickController2/BrickController2/DeviceManagement/PoweredUpDevice.cs
+++ b/BrickController2/BrickController2/DeviceManagement/PoweredUpDevice.cs
@@ -16,8 +16,8 @@ namespace BrickController2.DeviceManagement
         {
             RegisterPorts(new[]
             {
-                new DevicePort(0, "1"),
-                new DevicePort(1, "2"),
+                new DevicePort(0, "A"),
+                new DevicePort(1, "B"),
             });
         }
     }

--- a/BrickController2/BrickController2/DeviceManagement/PoweredUpDevice.cs
+++ b/BrickController2/BrickController2/DeviceManagement/PoweredUpDevice.cs
@@ -11,5 +11,14 @@ namespace BrickController2.DeviceManagement
 
         public override DeviceType DeviceType => DeviceType.PoweredUp;
         public override int NumberOfChannels => 2;
+
+        protected override void RegisterDefaultPorts()
+        {
+            RegisterPorts(new[]
+            {
+                new DevicePort(0, "1"),
+                new DevicePort(1, "2"),
+            });
+        }
     }
 }

--- a/BrickController2/BrickController2/DeviceManagement/SBrickDevice.cs
+++ b/BrickController2/BrickController2/DeviceManagement/SBrickDevice.cs
@@ -54,6 +54,17 @@ namespace BrickController2.DeviceManagement
             _sendAttemptsLeft = MAX_SEND_ATTEMPTS;
         }
 
+        protected override void RegisterDefaultPorts()
+        {
+            RegisterPorts(new[]
+            {
+                new DevicePort(0, "1"),
+                new DevicePort(1, "2"),
+                new DevicePort(2, "3"),
+                new DevicePort(3, "4"),
+            });
+        }
+
         protected override Task<bool> ValidateServicesAsync(IEnumerable<IGattService> services, CancellationToken token)
         {
             var deviceInformationService = services?.FirstOrDefault(s => s.Uuid == SERVICE_UUID_DEVICE_INFORMATION);

--- a/BrickController2/BrickController2/DeviceManagement/TechnicHubDevice.cs
+++ b/BrickController2/BrickController2/DeviceManagement/TechnicHubDevice.cs
@@ -12,5 +12,16 @@ namespace BrickController2.DeviceManagement
         public override DeviceType DeviceType => DeviceType.TechnicHub;
         public override int NumberOfChannels => 4;
 
+        protected override void RegisterDefaultPorts()
+        {
+            RegisterPorts(new[]
+            {
+                new DevicePort(0, "A"),
+                new DevicePort(1, "B"),
+                new DevicePort(2, "C"),
+                new DevicePort(3, "D"),
+            });
+        }
+
     }
 }

--- a/BrickController2/BrickController2/Helpers/DeviceExtensions.cs
+++ b/BrickController2/BrickController2/Helpers/DeviceExtensions.cs
@@ -1,0 +1,21 @@
+﻿using BrickController2.DeviceManagement;
+using BrickController2.UI.Services.Translation;
+using System.Linq;
+
+namespace BrickController2.Helpers
+{
+    public static class DeviceExtensions
+    {
+        public static string GetChannelName(this Device device, int channel, ITranslationService translationService = null)
+        {
+            var channelName = device?.RegisteredPorts.FirstOrDefault(p => p.Channel == channel)?.Name;
+
+            if (!string.IsNullOrEmpty(channelName))
+            {
+                channelName = translationService?.Translate(channelName);
+            }
+
+            return channelName ?? $"{channel + 1}";
+        }
+    }
+}

--- a/BrickController2/BrickController2/Helpers/ObservableCollectionExt.cs
+++ b/BrickController2/BrickController2/Helpers/ObservableCollectionExt.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+
+namespace BrickController2.Helpers
+{
+    /// <summary>
+    /// Observable generic collection allowing builk addition of items
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public class ObservableCollectionExt<T> : ObservableCollection<T>
+    {
+        public ObservableCollectionExt() : base()
+        {
+        } 
+
+        public ObservableCollectionExt(IEnumerable<T> collection) : base(collection)
+        {
+        }
+
+        public ObservableCollectionExt(List<T> list) : base(list)
+        {
+        }
+
+        /// <summary> 
+        /// Adds the elements of the specified collection to the end of the ObservableCollection(Of T). 
+        /// </summary> 
+        /// <remarks>No check on item duplicity during addition</remarks>
+        public void AddRange(IList<T> collection)
+        {
+            if (collection == null) throw new ArgumentNullException(nameof(collection));
+
+            foreach (var i in collection)
+            {
+                Items.Add(i);
+            }
+
+            OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, (System.Collections.IList)collection));
+        }
+    }
+}

--- a/BrickController2/BrickController2/UI/Controls/DeviceChannelSelector.xaml
+++ b/BrickController2/BrickController2/UI/Controls/DeviceChannelSelector.xaml
@@ -86,8 +86,8 @@
                 </Grid.ColumnDefinitions>
 
                 <Grid Grid.Column="0">
-                    <controls:ChannelSelectorRadioButton x:Name="PoweredUpChannel0" Channel="0" Text="1" HorizontalOptions="End" VerticalOptions="Start"/>
-                    <controls:ChannelSelectorRadioButton x:Name="PoweredUpChannel1" Channel="1" Text="2" HorizontalOptions="End" VerticalOptions="End"/>
+                    <controls:ChannelSelectorRadioButton x:Name="PoweredUpChannel0" Channel="0" Text="A" HorizontalOptions="End" VerticalOptions="Start"/>
+                    <controls:ChannelSelectorRadioButton x:Name="PoweredUpChannel1" Channel="1" Text="B" HorizontalOptions="End" VerticalOptions="End"/>
                 </Grid>
 
                 <Image Grid.Column="1" Source="{extensions:ImageResource Source=poweredup_image.png}" WidthRequest="150" HeightRequest="120"/>

--- a/BrickController2/BrickController2/UI/Controls/DeviceOutputTesterControl.xaml
+++ b/BrickController2/BrickController2/UI/Controls/DeviceOutputTesterControl.xaml
@@ -1,10 +1,43 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <ContentView xmlns="http://xamarin.com/schemas/2014/forms" 
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:controls="clr-namespace:BrickController2.UI.Controls"
+             xmlns:converters="clr-namespace:BrickController2.UI.Converters"
              x:Class="BrickController2.UI.Controls.DeviceOutputTesterControl">
 
+    <ContentView.Resources>
+        <ResourceDictionary>
+            <!-- Converters -->
+            <converters:DeviceConnectedToBoolConverter x:Key="DeviceConnectedToBool"/>
+            <converters:TextToCapitalInitialConverter x:Key="TextToCapitalInitial"/>
+            <converters:TextToColorConverter x:Key="TextToColor"/>
+        </ResourceDictionary>
+    </ContentView.Resources>    
+    
     <ContentView.Content>
-        <StackLayout x:Name="StackLayout" Orientation="Vertical">
+        <StackLayout BindableLayout.ItemsSource="{Binding ChannelOutputs, Mode=OneWay}" Orientation="Vertical">
+            <BindableLayout.ItemTemplate>
+                <DataTemplate>
+                    <Grid Padding="4">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="5"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+
+                        <Frame Grid.Column="0" WidthRequest="40" HeightRequest="40" BackgroundColor="{Binding Name, Converter={StaticResource TextToColor}}" CornerRadius="20" Padding="0" HasShadow="False" VerticalOptions="Center">
+                            <Label Text="{Binding Name, Converter={StaticResource TextToCapitalInitial}}" TextColor="White" FontSize="Medium" HorizontalOptions="Center" VerticalOptions="Center"/>
+                        </Frame>
+                        <controls:ExtendedSlider Grid.Column="2" HeightRequest="50" VerticalOptions="Center" MinimumTrackColor="LightGray" MaximumTrackColor="LightGray"
+                                                    Value="{Binding Output, Mode=TwoWay}"
+                                                    TouchUpCommand="{Binding TouchUpCommand}"
+                                                    IsEnabled="{Binding Device.DeviceState, Mode=Default, Converter={StaticResource DeviceConnectedToBool}}"
+                                                    Minimum="{Binding MinValue}"
+                                                    Maximum="{Binding MaxValue}"
+                                                    />
+                    </Grid>
+                </DataTemplate>
+            </BindableLayout.ItemTemplate>
         </StackLayout>
     </ContentView.Content>
 </ContentView>

--- a/BrickController2/BrickController2/UI/Controls/DeviceOutputTesterControl.xaml.cs
+++ b/BrickController2/BrickController2/UI/Controls/DeviceOutputTesterControl.xaml.cs
@@ -1,93 +1,14 @@
-﻿using BrickController2.Helpers;
-using BrickController2.UI.Converters;
-using System.Windows.Input;
-using Xamarin.Forms;
+﻿using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
-using Device = BrickController2.DeviceManagement.Device;
 
 namespace BrickController2.UI.Controls
 {
-	[XamlCompilation(XamlCompilationOptions.Compile)]
+    [XamlCompilation(XamlCompilationOptions.Compile)]
 	public partial class DeviceOutputTesterControl : ContentView
 	{
 		public DeviceOutputTesterControl ()
 		{
 			InitializeComponent ();
 		}
-
-        public static BindableProperty DeviceProperty = BindableProperty.Create(nameof(Device), typeof(Device), typeof(DeviceOutputTesterControl), propertyChanged: OnDeviceChanged);
-
-        public Device Device
-        {
-            get => (Device)GetValue(DeviceProperty);
-            set => SetValue(DeviceProperty, value);
-        }
-
-        private static void OnDeviceChanged(BindableObject bindable, object oldValue, object newValue)
-        {
-            if (bindable is DeviceOutputTesterControl dotc && newValue is Device device)
-            {
-                dotc.Setup(device);
-            }
-        }
-
-        private void Setup(Device device)
-        {
-            StackLayout.Children.Clear();
-
-            for (int channel = 0; channel < device.NumberOfChannels; channel++)
-            {
-                var deviceOutputViewModel = new DeviceOutputViewModel(device, channel);
-
-                var slider = new ExtendedSlider
-                {
-                    BindingContext = deviceOutputViewModel,
-                    HeightRequest = 50,
-                    MinimumTrackColor = Color.LightGray,
-                    MaximumTrackColor = Color.LightGray
-                };
-
-                slider.SetBinding(ExtendedSlider.ValueProperty, nameof(DeviceOutputViewModel.Output), BindingMode.TwoWay);
-                slider.SetBinding(ExtendedSlider.TouchUpCommandProperty, nameof(DeviceOutputViewModel.TouchUpCommand));
-                slider.SetBinding(ExtendedSlider.IsEnabledProperty, nameof(DeviceOutputViewModel.Device.DeviceState), BindingMode.Default, new DeviceConnectedToBoolConverter());
-                slider.SetBinding(ExtendedSlider.MinimumProperty, nameof(DeviceOutputViewModel.MinValue));
-                slider.SetBinding(ExtendedSlider.MaximumProperty, nameof(DeviceOutputViewModel.MaxValue));
-
-                StackLayout.Children.Add(slider);
-            }
-        }
-
-        private class DeviceOutputViewModel : NotifyPropertyChangedSource
-        {
-            private int _output;
-
-            public DeviceOutputViewModel(Device device, int channel)
-            {
-                Device = device;
-                Channel = channel;
-                Output = 0;
-
-                TouchUpCommand = new Command(() => Output = 0);
-            }
-
-            public Device Device { get; }
-            public int Channel { get; }
-
-            public int MinValue => -100;
-            public int MaxValue => 100;
-
-            public int Output
-            {
-                get { return _output; }
-                set
-                {
-                    _output = value;
-                    Device.SetOutput(Channel, (float)value / MaxValue);
-                    RaisePropertyChanged();
-                }
-            }
-
-            public ICommand TouchUpCommand { get; }
-        }
     }
 }

--- a/BrickController2/BrickController2/UI/Converters/TextToColorConverter.cs
+++ b/BrickController2/BrickController2/UI/Converters/TextToColorConverter.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using Xamarin.Forms;
+
+namespace BrickController2.UI.Converters
+{
+    public class TextToColorConverter : IValueConverter
+    {
+        /// <summary>
+        /// Get all known Xamarin colors
+        /// </summary>
+        private static readonly Dictionary<string, Color> KnownColors =
+            typeof(Color)
+            .GetProperties(BindingFlags.GetField | BindingFlags.Static | BindingFlags.Public)
+            .ToDictionary(p => p.Name, p => (Color)p.GetValue(null));
+
+        /// <summary>
+        /// Some list of different colors
+        /// </summary>
+        private static readonly Color[] Colors =
+        {
+            Color.LightGreen,
+            Color.MediumPurple,
+            Color.Orange,
+            Color.DeepSkyBlue,
+            Color.IndianRed,
+            Color.DeepPink,
+            Color.AliceBlue
+        };
+
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            var text = value as string;
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                return Color.DimGray;
+            }
+
+            if (KnownColors.TryGetValue(text, out var color))
+            {
+                return color;
+            }
+
+            // get color based on the first letter
+            return Colors[text[0] % Colors.Length];
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/BrickController2/BrickController2/UI/Pages/ChannelSetupPage.xaml
+++ b/BrickController2/BrickController2/UI/Pages/ChannelSetupPage.xaml
@@ -56,7 +56,7 @@
                         <Label Grid.Column="1" Grid.Row="1" Text="{Binding Device.DeviceType}" FontSize="Medium" FontAttributes="Bold"/>
 
                         <Label Grid.Column="0" Grid.Row="4" Text="{extensions:Translate Channel}" FontSize="Small"/>
-                        <Label Grid.Column="1" Grid.Row="4" Grid.ColumnSpan="2" Text="{Binding Action.Channel, Converter={StaticResource ChannelToDisplayChannel}}" FontSize="Medium" FontAttributes="Bold"/>
+                        <Label Grid.Column="1" Grid.Row="4" Grid.ColumnSpan="2" Text="{Binding ChannelName}" FontSize="Medium" FontAttributes="Bold"/>
                     </Grid>
                 </Grid>
 

--- a/BrickController2/BrickController2/UI/Pages/DevicePage.xaml
+++ b/BrickController2/BrickController2/UI/Pages/DevicePage.xaml
@@ -99,7 +99,7 @@
                 <!-- Outputs -->
                 <StackLayout Orientation="Vertical">
                     <BoxView BackgroundColor="#E0E0E0" HeightRequest="1" VerticalOptions="Center" HorizontalOptions="Fill" Margin="10,4,10,8"/>
-                    <controls:DeviceOutputTesterControl Device="{Binding Device}"/>
+                    <controls:DeviceOutputTesterControl />
                 </StackLayout> 
             
             </StackLayout>

--- a/BrickController2/BrickController2/UI/ViewModels/ChannelOutputViewModel.cs
+++ b/BrickController2/BrickController2/UI/ViewModels/ChannelOutputViewModel.cs
@@ -1,0 +1,42 @@
+﻿using BrickController2.DeviceManagement;
+using BrickController2.Helpers;
+using System.Windows.Input;
+
+namespace BrickController2.UI.ViewModels
+{
+    public class ChannelOutputViewModel : NotifyPropertyChangedSource
+    {
+        private int _output;
+
+        public ChannelOutputViewModel(Device device, DevicePort devicePort)
+        {
+            Device = device;
+            DevicePort = devicePort;
+            Output = 0;
+
+            TouchUpCommand = new Xamarin.Forms.Command(() => Output = 0);
+        }
+
+        public Device Device { get; }
+        public DevicePort DevicePort { get; }
+
+        public int Channel => DevicePort.Channel;
+        public string Name => DevicePort.Name;
+
+        public int MinValue => -100;
+        public int MaxValue => 100;
+
+        public int Output
+        {
+            get { return _output; }
+            set
+            {
+                _output = value;
+                Device.SetOutput(Channel, (float)value / MaxValue);
+                RaisePropertyChanged();
+            }
+        }
+
+        public ICommand TouchUpCommand { get; }
+    }
+}

--- a/BrickController2/BrickController2/UI/ViewModels/ChannelSetupPageViewModel.cs
+++ b/BrickController2/BrickController2/UI/ViewModels/ChannelSetupPageViewModel.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using System.Windows.Input;
 using BrickController2.CreationManagement;
 using BrickController2.DeviceManagement;
+using BrickController2.Helpers;
 using BrickController2.UI.Commands;
 using BrickController2.UI.Services.Dialog;
 using BrickController2.UI.Services.Navigation;
@@ -42,6 +43,7 @@ namespace BrickController2.UI.ViewModels
             Device = parameters.Get<Device>("device");
             Action = parameters.Get<ControllerAction>("controlleraction");
             ServoBaseAngle = Action.ServoBaseAngle;
+            ChannelName = Device.GetChannelName(Action.Channel, TranslationService);
 
             SaveChannelSettingsCommand = new SafeCommand(async () => await SaveChannelSettingsAsync());
             AutoCalibrateServoCommand = new SafeCommand(async () => await AutoCalibrateServoAsync());
@@ -50,6 +52,8 @@ namespace BrickController2.UI.ViewModels
 
         public Device Device { get; }
         public ControllerAction Action { get; }
+
+        public string ChannelName { get; } 
 
         public int ServoBaseAngle
         {

--- a/BrickController2/BrickController2/UI/ViewModels/ControllerProfilePageViewModel.cs
+++ b/BrickController2/BrickController2/UI/ViewModels/ControllerProfilePageViewModel.cs
@@ -9,6 +9,8 @@ using System.Collections.ObjectModel;
 using System;
 using System.Threading;
 using BrickController2.UI.Services.Translation;
+using System.Linq;
+using BrickController2.Helpers;
 
 namespace BrickController2.UI.ViewModels
 {
@@ -222,7 +224,7 @@ namespace BrickController2.UI.ViewModels
 
                 DeviceMissing = device == null;
                 DeviceName = device != null ? device.Name : Translate("Missing");
-                ChannelName = (device == null || device.DeviceType != DeviceType.Infrared) ? $"{controllerAction.Channel + 1}" : (controllerAction.Channel == 0 ? Translate("Blue") : Translate("Red"));
+                ChannelName = device.GetChannelName(controllerAction.Channel, _translationService);
                 InvertName = controllerAction.IsInvert ? Translate("Inv") : string.Empty;
             }
 

--- a/BrickController2/BrickController2/UI/ViewModels/DevicePageViewModel.cs
+++ b/BrickController2/BrickController2/UI/ViewModels/DevicePageViewModel.cs
@@ -10,6 +10,7 @@ using BrickController2.UI.Services.Dialog;
 using BrickController2.UI.Services.Translation;
 using BrickController2.UI.Services.UIThread;
 using Device = BrickController2.DeviceManagement.Device;
+using System.Collections.ObjectModel;
 
 namespace BrickController2.UI.ViewModels
 {
@@ -40,6 +41,8 @@ namespace BrickController2.UI.ViewModels
 
             Device = parameters.Get<Device>("device");
 
+            ChannelOutputs = new ObservableCollection<ChannelOutputViewModel>(Device.RegisteredPorts.Select(port => new ChannelOutputViewModel(Device, port)));
+
             RenameCommand = new SafeCommand(async () => await RenameDeviceAsync());
             BuWizzOutputLevelChangedCommand = new SafeCommand<int>(outputLevel => SetBuWizzOutputLevel(outputLevel));
             BuWizz2OutputLevelChangedCommand = new SafeCommand<int>(outputLevel => SetBuWizzOutputLevel(outputLevel));
@@ -48,6 +51,8 @@ namespace BrickController2.UI.ViewModels
         public Device Device { get; }
         public bool IsBuWizzDevice => Device.DeviceType == DeviceType.BuWizz;
         public bool IsBuWizz2Device => Device.DeviceType == DeviceType.BuWizz2;
+
+        public ObservableCollection<ChannelOutputViewModel> ChannelOutputs { get; }
 
         public ICommand RenameCommand { get; }
         public ICommand BuWizzOutputLevelChangedCommand { get; }


### PR DESCRIPTION
Based on my BC2 usage experience, I tried to improve channel name shown on following pages so as it's the same as on Controller Action page:
- Device (channel name + colored background)
- Controller profile (channel name)
- Channel setup (channel name)

Not sure if Buwizz2 is properly handled due to inner channel swapping.
If you find this usefull in general, please merge or use whatever part you find valuable.

![BC2 - colored channel names](https://user-images.githubusercontent.com/11756608/67889123-8fcb5880-fb4e-11e9-90d2-99bb99237b26.png)