### PR TITLE
Device test page - Show channel names

### DIFF
--- a/BrickController2/BrickController2/Helpers/ObservableExtensions.cs
+++ b/BrickController2/BrickController2/Helpers/ObservableExtensions.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace BrickController2.Helpers
+{
+    public static class ObservableExtensions
+    {
+        public static ObservableCollection<T> ToObservableCollection<T>(this IEnumerable<T> source)
+        {
+            return new ObservableCollection<T>(source);
+        }
+    }
+}

--- a/BrickController2/BrickController2/UI/Controls/DeviceOutputTesterControl.xaml
+++ b/BrickController2/BrickController2/UI/Controls/DeviceOutputTesterControl.xaml
@@ -1,10 +1,39 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <ContentView xmlns="http://xamarin.com/schemas/2014/forms" 
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:controls="clr-namespace:BrickController2.UI.Controls"
+             xmlns:converters="clr-namespace:BrickController2.UI.Converters"
              x:Class="BrickController2.UI.Controls.DeviceOutputTesterControl">
-
+    <ContentView.Resources>
+        <ResourceDictionary>
+            <!-- Converters -->
+            <converters:DeviceConnectedToBoolConverter x:Key="DeviceConnectedToBool"/>
+        </ResourceDictionary>
+    </ContentView.Resources>
+    
     <ContentView.Content>
-        <StackLayout x:Name="StackLayout" Orientation="Vertical">
+        <StackLayout BindableLayout.ItemsSource="{Binding ChannelOutputs, Mode=OneWay}" Orientation="Vertical">
+            <BindableLayout.ItemTemplate>
+                <DataTemplate>
+                    <Grid Padding="4">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="5"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+
+                        <controls:DeviceChannelLabel Grid.Column="0" DeviceType="{Binding Device.DeviceType}"  Channel="{Binding Channel}"
+                                                     FontSize="Medium" HorizontalOptions="Center" VerticalOptions="Center"/>
+                        <controls:ExtendedSlider Grid.Column="2" HeightRequest="50" VerticalOptions="Center" MinimumTrackColor="LightGray" MaximumTrackColor="LightGray"
+                                                    Value="{Binding Output, Mode=TwoWay}"
+                                                    TouchUpCommand="{Binding TouchUpCommand}"
+                                                    IsEnabled="{Binding Device.DeviceState, Mode=Default, Converter={StaticResource DeviceConnectedToBool}}"
+                                                    Minimum="{Binding MinValue}"
+                                                    Maximum="{Binding MaxValue}"
+                                                    />
+                    </Grid>
+                </DataTemplate>
+            </BindableLayout.ItemTemplate>
         </StackLayout>
     </ContentView.Content>
 </ContentView>

--- a/BrickController2/BrickController2/UI/Controls/DeviceOutputTesterControl.xaml.cs
+++ b/BrickController2/BrickController2/UI/Controls/DeviceOutputTesterControl.xaml.cs
@@ -1,93 +1,14 @@
-﻿using BrickController2.Helpers;
-using BrickController2.UI.Converters;
-using System.Windows.Input;
-using Xamarin.Forms;
+﻿using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
-using Device = BrickController2.DeviceManagement.Device;
 
 namespace BrickController2.UI.Controls
 {
-	[XamlCompilation(XamlCompilationOptions.Compile)]
+    [XamlCompilation(XamlCompilationOptions.Compile)]
 	public partial class DeviceOutputTesterControl : ContentView
 	{
 		public DeviceOutputTesterControl ()
 		{
 			InitializeComponent ();
 		}
-
-        public static BindableProperty DeviceProperty = BindableProperty.Create(nameof(Device), typeof(Device), typeof(DeviceOutputTesterControl), propertyChanged: OnDeviceChanged);
-
-        public Device Device
-        {
-            get => (Device)GetValue(DeviceProperty);
-            set => SetValue(DeviceProperty, value);
-        }
-
-        private static void OnDeviceChanged(BindableObject bindable, object oldValue, object newValue)
-        {
-            if (bindable is DeviceOutputTesterControl dotc && newValue is Device device)
-            {
-                dotc.Setup(device);
-            }
-        }
-
-        private void Setup(Device device)
-        {
-            StackLayout.Children.Clear();
-
-            for (int channel = 0; channel < device.NumberOfChannels; channel++)
-            {
-                var deviceOutputViewModel = new DeviceOutputViewModel(device, channel);
-
-                var slider = new ExtendedSlider
-                {
-                    BindingContext = deviceOutputViewModel,
-                    HeightRequest = 50,
-                    MinimumTrackColor = Color.LightGray,
-                    MaximumTrackColor = Color.LightGray
-                };
-
-                slider.SetBinding(ExtendedSlider.ValueProperty, nameof(DeviceOutputViewModel.Output), BindingMode.TwoWay);
-                slider.SetBinding(ExtendedSlider.TouchUpCommandProperty, nameof(DeviceOutputViewModel.TouchUpCommand));
-                slider.SetBinding(ExtendedSlider.IsEnabledProperty, nameof(DeviceOutputViewModel.Device.DeviceState), BindingMode.Default, new DeviceConnectedToBoolConverter());
-                slider.SetBinding(ExtendedSlider.MinimumProperty, nameof(DeviceOutputViewModel.MinValue));
-                slider.SetBinding(ExtendedSlider.MaximumProperty, nameof(DeviceOutputViewModel.MaxValue));
-
-                StackLayout.Children.Add(slider);
-            }
-        }
-
-        private class DeviceOutputViewModel : NotifyPropertyChangedSource
-        {
-            private int _output;
-
-            public DeviceOutputViewModel(Device device, int channel)
-            {
-                Device = device;
-                Channel = channel;
-                Output = 0;
-
-                TouchUpCommand = new Command(() => Output = 0);
-            }
-
-            public Device Device { get; }
-            public int Channel { get; }
-
-            public int MinValue => -100;
-            public int MaxValue => 100;
-
-            public int Output
-            {
-                get { return _output; }
-                set
-                {
-                    _output = value;
-                    Device.SetOutput(Channel, (float)value / MaxValue);
-                    RaisePropertyChanged();
-                }
-            }
-
-            public ICommand TouchUpCommand { get; }
-        }
     }
 }

--- a/BrickController2/BrickController2/UI/Pages/DevicePage.xaml
+++ b/BrickController2/BrickController2/UI/Pages/DevicePage.xaml
@@ -99,7 +99,7 @@
                 <!-- Outputs -->
                 <StackLayout Orientation="Vertical">
                     <BoxView BackgroundColor="#E0E0E0" HeightRequest="1" VerticalOptions="Center" HorizontalOptions="Fill" Margin="10,4,10,8"/>
-                    <controls:DeviceOutputTesterControl Device="{Binding Device}"/>
+                    <controls:DeviceOutputTesterControl />
                 </StackLayout> 
             
             </StackLayout>

--- a/BrickController2/BrickController2/UI/ViewModels/DeviceChannelOutputViewModel.cs
+++ b/BrickController2/BrickController2/UI/ViewModels/DeviceChannelOutputViewModel.cs
@@ -1,0 +1,43 @@
+﻿using BrickController2.DeviceManagement;
+using BrickController2.Helpers;
+using System.Windows.Input;
+using Xamarin.Forms;
+using Device = BrickController2.DeviceManagement.Device;
+
+namespace BrickController2.UI.ViewModels
+{
+    // Copied out from BrickController2.UI.Controls.DeviceOutputTesterControl.DeviceOutputViewModel
+    public class DeviceChannelOutputViewModel : NotifyPropertyChangedSource
+    {
+        private int _output;
+
+        public DeviceChannelOutputViewModel(Device device, int channel)
+        {
+            Device = device;
+            Channel = channel;
+            Output = 0;
+
+            TouchUpCommand = new Command(() => Output = 0);
+        }
+
+        public Device Device { get; }
+        public DeviceType DeviceType => Device.DeviceType;
+        public int Channel { get; }
+
+        public int MinValue => -100;
+        public int MaxValue => 100;
+
+        public int Output
+        {
+            get { return _output; }
+            set
+            {
+                _output = value;
+                Device.SetOutput(Channel, (float)value / MaxValue);
+                RaisePropertyChanged();
+            }
+        }
+
+        public ICommand TouchUpCommand { get; }
+    }
+}

--- a/BrickController2/BrickController2/UI/ViewModels/DevicePageViewModel.cs
+++ b/BrickController2/BrickController2/UI/ViewModels/DevicePageViewModel.cs
@@ -10,6 +10,8 @@ using BrickController2.UI.Services.Dialog;
 using BrickController2.UI.Services.Translation;
 using BrickController2.UI.Services.UIThread;
 using Device = BrickController2.DeviceManagement.Device;
+using System.Collections.ObjectModel;
+using BrickController2.Helpers;
 
 namespace BrickController2.UI.ViewModels
 {
@@ -39,6 +41,9 @@ namespace BrickController2.UI.ViewModels
             _uIThreadService = uIThreadService;
 
             Device = parameters.Get<Device>("device");
+            ChannelOutputs = Enumerable.Range(0, Device.NumberOfChannels)
+                    .Select(channel => new DeviceChannelOutputViewModel(Device, channel))
+                    .ToObservableCollection();
 
             RenameCommand = new SafeCommand(async () => await RenameDeviceAsync());
             BuWizzOutputLevelChangedCommand = new SafeCommand<int>(outputLevel => SetBuWizzOutputLevel(outputLevel));
@@ -55,6 +60,8 @@ namespace BrickController2.UI.ViewModels
 
         public int BuWizzOutputLevel { get; set; } = 1;
         public int BuWizz2OutputLevel { get; set; } = 1;
+
+        public ObservableCollection<DeviceChannelOutputViewModel> ChannelOutputs { get; }
 
         public override async void OnAppearing()
         {


### PR DESCRIPTION
Simplified changes from the previous #19 to reuse recent channel naming code.
![BC2 - channel names](https://user-images.githubusercontent.com/11756608/71490144-a4179300-2829-11ea-8b48-7e21152e8633.jpg)
