### PR TITLE
Prevent crashes when Xamarin Forms 4.4 for UWP is used

### DIFF
--- a/BrickController2/BrickController2/Helpers/ResourceHelper.cs
+++ b/BrickController2/BrickController2/Helpers/ResourceHelper.cs
@@ -1,6 +1,7 @@
 ﻿using BrickController2.Resources;
 using System.Reflection;
 using System.Resources;
+using Xamarin.Forms;
 
 namespace BrickController2.Helpers
 {
@@ -22,5 +23,11 @@ namespace BrickController2.Helpers
         }
 
         public static string ImageResourceRootNameSpace => "BrickController2.UI.Images";
+
+        public static ImageSource GetImageResource(string resourceName)
+        {
+            // define sourceAssembly parameter to avoid looking for assembly by Xamarin (via reflection of Assembly.GetCallingAssembly)
+            return ImageSource.FromResource($"{ImageResourceRootNameSpace}.{resourceName}", typeof(ResourceHelper).Assembly);
+        }
     }
 }

--- a/BrickController2/BrickController2/UI/Converters/DeviceTypeToImageConverter.cs
+++ b/BrickController2/BrickController2/UI/Converters/DeviceTypeToImageConverter.cs
@@ -20,25 +20,25 @@ namespace BrickController2.UI.Converters
             {
                 case DeviceType.BuWizz:
                 case DeviceType.BuWizz2:
-                    return ImageSource.FromResource($"{ResourceHelper.ImageResourceRootNameSpace}.buwizz_image.png");
+                    return ResourceHelper.GetImageResource("buwizz_image.png");
 
                 case DeviceType.SBrick:
-                    return ImageSource.FromResource($"{ResourceHelper.ImageResourceRootNameSpace}.sbrick_image.png");
+                    return ResourceHelper.GetImageResource("sbrick_image.png");
 
                 case DeviceType.Infrared:
-                    return ImageSource.FromResource($"{ResourceHelper.ImageResourceRootNameSpace}.infra_image.png");
+                    return ResourceHelper.GetImageResource("infra_image.png");
 
                 case DeviceType.PoweredUp:
-                    return ImageSource.FromResource($"{ResourceHelper.ImageResourceRootNameSpace}.poweredup_image.png");
+                    return ResourceHelper.GetImageResource("poweredup_image.png");
 
                 case DeviceType.Boost:
-                    return ImageSource.FromResource($"{ResourceHelper.ImageResourceRootNameSpace}.boost_image.png");
+                    return ResourceHelper.GetImageResource("boost_image.png");
 
                 case DeviceType.TechnicHub:
-                    return ImageSource.FromResource($"{ResourceHelper.ImageResourceRootNameSpace}.technichub_image.png");
+                    return ResourceHelper.GetImageResource("technichub_image.png");
 
                 case DeviceType.DuploTrainHub:
-                    return ImageSource.FromResource($"{ResourceHelper.ImageResourceRootNameSpace}.duplotrainhub_image.png");
+                    return ResourceHelper.GetImageResource("duplotrainhub_image.png");
 
                 default:
                     return null;

--- a/BrickController2/BrickController2/UI/Converters/DeviceTypeToSmallImageConverter.cs
+++ b/BrickController2/BrickController2/UI/Converters/DeviceTypeToSmallImageConverter.cs
@@ -15,25 +15,25 @@ namespace BrickController2.UI.Converters
             {
                 case DeviceType.BuWizz:
                 case DeviceType.BuWizz2:
-                   return ImageSource.FromResource($"{ResourceHelper.ImageResourceRootNameSpace}.buwizz_image_small.png");
+                   return ResourceHelper.GetImageResource("buwizz_image_small.png");
 
                 case DeviceType.SBrick:
-                    return ImageSource.FromResource($"{ResourceHelper.ImageResourceRootNameSpace}.sbrick_image_small.png");
+                    return ResourceHelper.GetImageResource("sbrick_image_small.png");
 
                 case DeviceType.Infrared:
-                    return ImageSource.FromResource($"{ResourceHelper.ImageResourceRootNameSpace}.infra_image_small.png");
+                    return ResourceHelper.GetImageResource("infra_image_small.png");
 
                 case DeviceType.PoweredUp:
-                    return ImageSource.FromResource($"{ResourceHelper.ImageResourceRootNameSpace}.poweredup_image_small.png");
+                    return ResourceHelper.GetImageResource("poweredup_image_small.png");
 
                 case DeviceType.Boost:
-                    return ImageSource.FromResource($"{ResourceHelper.ImageResourceRootNameSpace}.boost_image_small.png");
+                    return ResourceHelper.GetImageResource("boost_image_small.png");
 
                 case DeviceType.TechnicHub:
-                    return ImageSource.FromResource($"{ResourceHelper.ImageResourceRootNameSpace}.technichub_image_small.png");
+                    return ResourceHelper.GetImageResource("technichub_image_small.png");
 
                 case DeviceType.DuploTrainHub:
-                    return ImageSource.FromResource($"{ResourceHelper.ImageResourceRootNameSpace}.duplotrainhub_image_small.png");
+                    return ResourceHelper.GetImageResource("duplotrainhub_image_small.png");
 
                 default:
                     return null;

--- a/BrickController2/BrickController2/UI/Converters/GameControllerEventTypeToImageConverter.cs
+++ b/BrickController2/BrickController2/UI/Converters/GameControllerEventTypeToImageConverter.cs
@@ -19,10 +19,10 @@ namespace BrickController2.UI.Converters
             switch (eventType)
             {
                 case GameControllerEventType.Button:
-                    return ImageSource.FromResource($"{ResourceHelper.ImageResourceRootNameSpace}.ic_buttons.png");
+                    return ResourceHelper.GetImageResource("ic_buttons.png");
 
                 case GameControllerEventType.Axis:
-                    return ImageSource.FromResource($"{ResourceHelper.ImageResourceRootNameSpace}.ic_joystick.png");
+                    return ResourceHelper.GetImageResource("ic_joystick.png");
 
                 default:
                     return null;

--- a/BrickController2/BrickController2/UI/MarkupExtensions/ImageResourceExtension.cs
+++ b/BrickController2/BrickController2/UI/MarkupExtensions/ImageResourceExtension.cs
@@ -27,7 +27,7 @@ namespace BrickController2.UI.MarkupExtensions
                 return null;
             }
 
-            return ImageSource.FromResource($"{ResourceHelper.ImageResourceRootNameSpace}.{Source}");
+            return ResourceHelper.GetImageResource(Source);
         }
     }
 }


### PR DESCRIPTION
Hi,
seems the recent update to Xamarin Forms 4.4 caused crashes in my experimental version of BrickController for UWP platform.
I've reported bug https://github.com/xamarin/Xamarin.Forms/issues/9002, but when I see the number of issues, it's easier to apply a workaround here in your app. It's quite simply, passing `sourceAssembly` parameter for `ImageSource.FromResource` to prevent crashes when Xamarin Forms 4.4 for UWP is used.
Please consider to apply it even it does not affect neither Android nor iOS.