### PR TITLE
Dead zone behaviour fix

### DIFF
--- a/BrickController2/BrickController2/BusinessLogic/PlayLogic.cs
+++ b/BrickController2/BrickController2/BusinessLogic/PlayLogic.cs
@@ -222,7 +222,7 @@ namespace BrickController2.BusinessLogic
             {
                 if (Math.Abs(axisValue) <= axisDeadZone)
                 {
-                    return (false, 0);
+                    return (true, 0);
                 }
 
                 if (axisValue < 0)


### PR DESCRIPTION
With a dead zone set, you often end up with a motor "creeping" when the controller input returns to centre.  

This is because `ProcessAxisEvent` specifies `useAxisValue` as false whenever it's in the dead zone, which means the output never actually gets set to zero.