### PR TITLE
Support for devices powered by BuWizz

### DIFF
--- a/BrickController2/BrickController2/Resources/TranslationResources.Designer.cs
+++ b/BrickController2/BrickController2/Resources/TranslationResources.Designer.cs
@@ -763,6 +763,15 @@ namespace BrickController2.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to {0} of {1} device(s) connected.
+        /// </summary>
+        internal static string NofMDevicesConnected {
+            get {
+                return ResourceManager.GetString("NofMDevicesConnected", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to There are no sequences..
         /// </summary>
         internal static string NoSequences {

--- a/BrickController2/BrickController2/Resources/TranslationResources.resx
+++ b/BrickController2/BrickController2/Resources/TranslationResources.resx
@@ -351,6 +351,9 @@
   <data name="NoControllerActions" xml:space="preserve">
     <value>There are no controller actions added to the creation.</value>
   </data>
+  <data name="NofMDevicesConnected" xml:space="preserve">
+    <value>{0} of {1} device(s) connected</value>
+  </data>
   <data name="NoSequences" xml:space="preserve">
     <value>There are no sequences.</value>
   </data>

--- a/BrickController2/BrickController2/UI/ViewModels/DevicePageViewModel.cs
+++ b/BrickController2/BrickController2/UI/ViewModels/DevicePageViewModel.cs
@@ -150,16 +150,16 @@ namespace BrickController2.UI.ViewModels
                 false,
                 async (progressDialog, token) =>
                 {
-                 using (token.Register(() => _connectionTokenSource?.Cancel()))
-                  {
-                     connectionResult = await Device.ConnectAsync(
-                         _reconnect,
-                         OnDeviceDisconnected,
-                         Enumerable.Empty<ChannelConfiguration>(),
-                         true,
-                         true,
-                         _connectionTokenSource.Token);
-                  }
+                    using (token.Register(() => _connectionTokenSource?.Cancel()))
+                    {
+                        connectionResult = await Device.ConnectAsync(
+                        _reconnect,
+                        OnDeviceDisconnected,
+                        Enumerable.Empty<ChannelConfiguration>(),
+                        true,
+                        true,
+                        _connectionTokenSource.Token);
+                    }
                 },
                 Translate("Connecting"),
                 null,

--- a/BrickController2/BrickController2/UI/ViewModels/DevicePageViewModel.cs
+++ b/BrickController2/BrickController2/UI/ViewModels/DevicePageViewModel.cs
@@ -100,7 +100,7 @@ namespace BrickController2.UI.ViewModels
                 await _connectionTask;
             }
 
-            await Device.DisconnectAsync();
+            //await Device.DisconnectAsync();
         }
 
         private async Task RenameDeviceAsync()
@@ -142,30 +142,32 @@ namespace BrickController2.UI.ViewModels
 
         private async Task ConnectAsync()
         {
-            _connectionTokenSource = new CancellationTokenSource();
             DeviceConnectionResult connectionResult = DeviceConnectionResult.Ok;
 
-            await _dialogService.ShowProgressDialogAsync(
+            if (Device.DeviceState != DeviceState.Connected) {
+                _connectionTokenSource = new CancellationTokenSource();
+                await _dialogService.ShowProgressDialogAsync(
                 false,
                 async (progressDialog, token) =>
                 {
-                    using (token.Register(() => _connectionTokenSource?.Cancel()))
-                    {
-                        connectionResult = await Device.ConnectAsync(
-                            _reconnect,
-                            OnDeviceDisconnected,
-                            Enumerable.Empty<ChannelConfiguration>(),
-                            true,
-                            true,
-                            _connectionTokenSource.Token);
-                    }
+                 using (token.Register(() => _connectionTokenSource?.Cancel()))
+                  {
+                     connectionResult = await Device.ConnectAsync(
+                         _reconnect,
+                         OnDeviceDisconnected,
+                         Enumerable.Empty<ChannelConfiguration>(),
+                         true,
+                         true,
+                         _connectionTokenSource.Token);
+                  }
                 },
                 Translate("Connecting"),
                 null,
                 Translate("Cancel"));
 
-            _connectionTokenSource.Dispose();
-            _connectionTokenSource = null;
+                _connectionTokenSource.Dispose();
+                _connectionTokenSource = null;
+            }
 
             if (Device.DeviceState == DeviceState.Connected)
             {


### PR DESCRIPTION
This PR adds support for hubs that are powered by BuWizz hubs.  BuWizz hubs do not provide any power output when not connected via Bluetooth, making connections to any attached hubs impossible if the BW hub is not connected first.

This PR:

* Does not disconnect hubs when leaving the device details page, allowing other hubs to be discovered by scanning, connecting to BW, then scanning again.
* Checks if a hub is already connected when selecting the device details page
* Ensures that BuWizz devices are connected before other hubs when going to the play page
* Shows progress (number of hubs connected) during the connection process.

Fixes #43 