### PR TITLE
Honour invert setting with sequences

### DIFF
--- a/BrickController2/BrickController2/BusinessLogic/ISequencePlayer.cs
+++ b/BrickController2/BrickController2/BusinessLogic/ISequencePlayer.cs
@@ -7,6 +7,6 @@ namespace BrickController2.BusinessLogic
         void StartPlayer();
         void StopPlayer();
 
-        void ToggleSequence(string deviceId, int channel, Sequence sequence);
+        void ToggleSequence(string deviceId, int channel, bool invert, Sequence sequence);
     }
 }

--- a/BrickController2/BrickController2/BusinessLogic/PlayLogic.cs
+++ b/BrickController2/BrickController2/BusinessLogic/PlayLogic.cs
@@ -181,7 +181,7 @@ namespace BrickController2.BusinessLogic
                     var sequence = _creationManager.Sequences.FirstOrDefault(s => s.Name == controllerAction.SequenceName);
                     if (sequence != null)
                     {
-                        _sequencePlayer.ToggleSequence(controllerAction.DeviceId, controllerAction.Channel, sequence);
+                        _sequencePlayer.ToggleSequence(controllerAction.DeviceId, controllerAction.Channel, controllerAction.IsInvert, sequence);
                     }
                     break;
             }


### PR DESCRIPTION
It's possible to set the "invert" flag when invoking a sequence from a controller action, but it doesn't do anything.  This PR changes this so that if you set the invert flag, the output is reversed.

This is useful for me, as I have a channel with cross-wired LEDs for turn signals, so using "invert" allows me to re-use the same sequence for both directions, but I suspect that it may be useful in other situations.