### PR TITLE
Unregister dialog server only if both instances are the same

### DIFF
--- a/BrickController2/BrickController2/UI/Services/Dialog/DialogService.cs
+++ b/BrickController2/BrickController2/UI/Services/Dialog/DialogService.cs
@@ -57,7 +57,9 @@ namespace BrickController2.UI.Services.Dialog
 
         public void UnregisterDialogServer(IDialogServer dialogServer)
         {
-            _dialogServer = null;
+            // reset only in case previously set server matches
+            if (_dialogServer == dialogServer)
+                _dialogServer = null;
         }
     }
 }


### PR DESCRIPTION
When navigation page is changed on UWP platform `PageBase.OnDisappearing` of the previous page is called after `PageBase.OnAppearing` of the new one. Therefore no dialog server was set as it was reset by `UnregisterDialogServer`.
Added condition so as stored dialog server is reset only if unregistration is called for currently stored instance.