### PR TITLE
Make BluetoothDevice.Disconnect asynchronous

### DIFF
--- a/BrickController2/BrickController2.Android/PlatformServices/BluetoothLE/BluetoothLEDevice.cs
+++ b/BrickController2/BrickController2.Android/PlatformServices/BluetoothLE/BluetoothLEDevice.cs
@@ -104,26 +104,34 @@ namespace BrickController2.Droid.PlatformServices.BluetoothLE
             }
         }
 
-        public void Disconnect()
+        internal void Disconnect()
         {
-            lock(_lock)
+
+            _onDeviceDisconnected = null;
+            _onCharacteristicChanged = null;
+
+            if (_bluetoothGatt != null)
             {
-                _onDeviceDisconnected = null;
-                _onCharacteristicChanged = null;
+                _bluetoothGatt.Disconnect();
+                _bluetoothGatt.Close();
+                _bluetoothGatt.Dispose();
+                _bluetoothGatt = null;
 
-                if (_bluetoothGatt != null)
-                {
-                    _bluetoothGatt.Disconnect();
-                    _bluetoothGatt.Close();
-                    _bluetoothGatt.Dispose();
-                    _bluetoothGatt = null;
-
-                    _bluetoothDevice.Dispose();
-                    _bluetoothDevice = null;
-                }
-
-                State = BluetoothLEDeviceState.Disconnected;
+                _bluetoothDevice.Dispose();
+                _bluetoothDevice = null;
             }
+
+            State = BluetoothLEDeviceState.Disconnected;
+        }
+
+        public Task DisconnectAsync()
+        {
+            lock (_lock)
+            {
+                Disconnect();
+            }
+
+            return Task.CompletedTask;
         }
 
         public Task<bool> EnableNotificationAsync(IGattCharacteristic characteristic, CancellationToken token)

--- a/BrickController2/BrickController2.iOS/PlatformServices/BluetoothLE/BluetoothLEDevice.cs
+++ b/BrickController2/BrickController2.iOS/PlatformServices/BluetoothLE/BluetoothLEDevice.cs
@@ -73,16 +73,23 @@ namespace BrickController2.iOS.PlatformServices.BluetoothLE
             }
         }
 
-        public void Disconnect()
+        internal void Disconnect()
+        {
+            _onDeviceDisconnected = null;
+            _onCharacteristicChanged = null;
+
+            _centralManager.CancelPeripheralConnection(_peripheral);
+            State = BluetoothLEDeviceState.Disconnected;
+        }
+
+        public Task DisconnectAsync()
         {
             lock (_lock)
             {
-                _onDeviceDisconnected = null;
-                _onCharacteristicChanged = null;
-
-                _centralManager.CancelPeripheralConnection(_peripheral);
-                State = BluetoothLEDeviceState.Disconnected;
+                Disconnect();
             }
+
+            return Task.CompletedTask;
         }
 
         public Task<bool> EnableNotificationAsync(IGattCharacteristic characteristic, CancellationToken token)

--- a/BrickController2/BrickController2/DeviceManagement/BluetoothDevice.cs
+++ b/BrickController2/BrickController2/DeviceManagement/BluetoothDevice.cs
@@ -116,7 +116,7 @@ namespace BrickController2.DeviceManagement
             {
                 await StopOutputTaskAsync();
                 DeviceState = DeviceState.Disconnecting;
-                _bleDevice.Disconnect();
+                await _bleDevice.DisconnectAsync();
                 _bleDevice = null;
             }
 

--- a/BrickController2/BrickController2/PlatformServices/BluetoothLE/IBluetoothLEDevice.cs
+++ b/BrickController2/BrickController2/PlatformServices/BluetoothLE/IBluetoothLEDevice.cs
@@ -15,7 +15,7 @@ namespace BrickController2.PlatformServices.BluetoothLE
             Action<Guid, byte[]> onCharacteristicChanged,
             Action<IBluetoothLEDevice> onDeviceDisconnected,
             CancellationToken token);
-        void Disconnect();
+        Task DisconnectAsync();
 
         Task<bool> EnableNotificationAsync(IGattCharacteristic characteristic, CancellationToken token);
 


### PR DESCRIPTION
This is a minor improvement made due to my UWP implementation of BrickController so as bluetooth device implementation for Windows can have proper full async implementation without using of `Wait` or `GetAwaiter().GetResults()`.
I'm trying to avoid such sync waiting patern:
```
public void Disconnect()
{
     DisconnectAsync().Wait();
}
```
Additionally removed lock from `Disconnect` method as all it's calls are already par of such locks and its successor usage is already async:
https://github.com/vicocz/brickcontroller2/blob/3a725fc039f33cdd73dffdf5d70a0a716ff41542/BrickController2/BrickController2/DeviceManagement/BluetoothDevice.cs#L119