### PR TITLE
Await completion of WriteDescriptor to avoid possible failuress of next operation

### DIFF
--- a/BrickController2/BrickController2.Android/PlatformServices/BluetoothLE/BluetoothLEDevice.cs
+++ b/BrickController2/BrickController2.Android/PlatformServices/BluetoothLE/BluetoothLEDevice.cs
@@ -26,6 +26,7 @@ namespace BrickController2.Droid.PlatformServices.BluetoothLE
         private TaskCompletionSource<IEnumerable<IGattService>> _connectCompletionSource = null;
         private TaskCompletionSource<byte[]> _readCompletionSource = null;
         private TaskCompletionSource<bool> _writeCompletionSource = null;
+        private TaskCompletionSource<bool> _descriptorWriteCompletionSource = null;
 
         private Action<Guid, byte[]> _onCharacteristicChanged = null;
         private Action<IBluetoothLEDevice> _onDeviceDisconnected = null;
@@ -126,34 +127,55 @@ namespace BrickController2.Droid.PlatformServices.BluetoothLE
             }
         }
 
-        public Task<bool> EnableNotificationAsync(IGattCharacteristic characteristic, CancellationToken token)
+        public async Task<bool> EnableNotificationAsync(IGattCharacteristic characteristic, CancellationToken token)
         {
+            using (token.Register(() =>
+            {
+                lock (_lock)
+                {
+                    _descriptorWriteCompletionSource?.TrySetResult(false);
+                }
+            }))
+
             lock (_lock)
             {
                 if (_bluetoothGatt == null || State != BluetoothLEDeviceState.Connected)
                 {
-                    return Task.FromResult(false);
+                    return false;
                 }
 
                 var nativeCharacteristic = ((GattCharacteristic)characteristic).BluetoothGattCharacteristic;
                 if (!_bluetoothGatt.SetCharacteristicNotification(nativeCharacteristic, true))
                 {
-                    return Task.FromResult(false);
+                    return false;
                 }
 
                 var descriptor = nativeCharacteristic.GetDescriptor(ClientCharacteristicConfigurationUUID);
                 if (descriptor == null)
                 {
-                    return Task.FromResult(false);
+                    return false;
                 }
 
                 if (!descriptor.SetValue(BluetoothGattDescriptor.EnableNotificationValue.ToArray()))
                 {
-                    return Task.FromResult(false);
+                    return false;
                 }
 
-                var result = _bluetoothGatt.WriteDescriptor(descriptor);
-                return Task.FromResult(result);
+                _descriptorWriteCompletionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+                if (!_bluetoothGatt.WriteDescriptor(descriptor))
+                {
+                    _descriptorWriteCompletionSource = null;
+                    return false;
+                }
+            }
+
+            var result = await _descriptorWriteCompletionSource.Task.ConfigureAwait(false);
+
+            lock (_lock)
+            {
+                _descriptorWriteCompletionSource = null;
+                return result;
             }
         }
 
@@ -376,6 +398,14 @@ namespace BrickController2.Droid.PlatformServices.BluetoothLE
             lock (_lock)
             {
                 _writeCompletionSource?.TrySetResult(status == GattStatus.Success);
+            }
+        }
+
+        public override void OnDescriptorWrite(BluetoothGatt gatt, BluetoothGattDescriptor descriptor, [GeneratedEnum] GattStatus status)
+        {
+            lock (_lock)
+            {
+                _descriptorWriteCompletionSource?.TrySetResult(status == GattStatus.Success);
             }
         }
 


### PR DESCRIPTION
Ocassionally BLE read operation was failing when executed shortly after `BluetoothLEDevice.EnableNotificationAsync`. Seems there used to be a race condition that [WriteDescriptor](https://github.com/vicocz/brickcontroller2/blob/a12c35befefb36b9245aedfdcee5f74e48be8ca3/BrickController2/BrickController2.Android/PlatformServices/BluetoothLE/BluetoothLEDevice.cs#L174) was not awaiting its completion as e.g. read / write does.
This fix resolves https://github.com/vicocz/brickcontroller2/issues/10.

https://stackoverflow.com/questions/53937238/unable-to-read-characteristic-using-bluetooth-le-readcharacteristic-returns-fal