### PR TITLE
Fix condition of non-looped seqence when it has reached end

### DIFF
--- a/BrickController2/BrickController2/BusinessLogic/SequencePlayer.cs
+++ b/BrickController2/BrickController2/BusinessLogic/SequencePlayer.cs
@@ -123,7 +123,7 @@ namespace BrickController2.BusinessLogic
             var sequenceDurationMs = sequence.TotalDurationMs;
             var elapsedTimeMs = nowMs - startTimeMs;
 
-            if ((!sequence.Loop && (sequenceDurationMs < elapsedTimeMs)) || sequenceDurationMs == 0)
+            if ((!sequence.Loop && (sequenceDurationMs <= elapsedTimeMs)) || sequenceDurationMs == 0)
             {
                 // Sequence is not looping and has finished
                 return false;


### PR DESCRIPTION
When total duration of non-looped sequence is multiple of 50 ms, the last evaluated value is taken from the first control point instead of ending of sequence.
Fixes #102