### PR TITLE
Remove binding hack in order to properly show control points after deletion

### DIFF
--- a/BrickController2/BrickController2/UI/ViewModels/SequenceEditorPageViewModel.cs
+++ b/BrickController2/BrickController2/UI/ViewModels/SequenceEditorPageViewModel.cs
@@ -202,9 +202,6 @@ namespace BrickController2.UI.ViewModels
                     _disappearingTokenSource.Token))
                 {
                     Sequence.ControlPoints.Remove(controlPoint);
-
-                    // This hack is needed to rebuild the bindings properly in the listview
-                    Sequence.ControlPoints = new ObservableCollection<SequenceControlPoint>(Sequence.ControlPoints);
                 }
             }
             catch (OperationCanceledException)


### PR DESCRIPTION
Seems that the hack was addressing some issue in past which has been resolved in Xamarin now. For details, see #106.
Resolves #106. 