### PR TITLE
Fix inner exception for the first round of a sequence play

### DIFF
--- a/BrickController2/BrickController2/BusinessLogic/SequencePlayer.cs
+++ b/BrickController2/BrickController2/BusinessLogic/SequencePlayer.cs
@@ -90,15 +90,18 @@ namespace BrickController2.BusinessLogic
 
                     foreach (var kvp in _sequences)
                     {
+                        var key = kvp.Key;
+                        var value = kvp.Value;
                         // Start the sequence "now" if it hasn't been started yet
-                        if (!kvp.Value.StartTimeMs.HasValue)
+                        if (!value.StartTimeMs.HasValue)
                         {
-                            _sequences[kvp.Key] = (kvp.Value.Sequence, kvp.Value.Invert, _timeSinceStartMs);
+                            value = (value.Sequence, value.Invert, _timeSinceStartMs);
+                            _sequences[key] = value;
                         }
 
-                        if (!ProcessSequence(kvp.Key.DeviceId, kvp.Key.Channel, kvp.Value.Sequence, kvp.Value.Invert, kvp.Value.StartTimeMs!.Value, _timeSinceStartMs))
+                        if (!ProcessSequence(key.DeviceId, key.Channel, value.Sequence, value.Invert, value.StartTimeMs!.Value, _timeSinceStartMs))
                         {
-                            sequencesToRemove.Add((kvp.Key.DeviceId, kvp.Key.Channel));
+                            sequencesToRemove.Add((key.DeviceId, key.Channel));
                         }
                     }
 


### PR DESCRIPTION
There is inner exception, hidden to user, which regularly occurs when a sequence is played for the first time and `kvp.Value.StartTimeMs` is null as it was updated in `_sequences` only. THe only consequence of this failure is IMHO the timing, the sequence is effectively started 50 ms later. So nearly no impact for user.

![image](https://github.com/user-attachments/assets/04e1c7f9-df65-44c7-bf7e-eca0a9f51ab8)
