### PR TITLE
Show MaxServo settings for ServoMotor output only

### DIFF
--- a/BrickController2/BrickController2/UI/Converters/DeviceAndChannelOutputTypeToMaxServoAngleVisibleConverter.cs
+++ b/BrickController2/BrickController2/UI/Converters/DeviceAndChannelOutputTypeToMaxServoAngleVisibleConverter.cs
@@ -1,17 +1,19 @@
 ﻿using System;
 using System.Globalization;
+using BrickController2.CreationManagement;
 using Microsoft.Maui.Controls;
 using Device = BrickController2.DeviceManagement.Device;
 
 namespace BrickController2.UI.Converters
 {
-    internal class DeviceAndChannelToMaxServoAngleVisibleConverter : IMultiValueConverter
+    internal class DeviceAndChannelOutputTypeToMaxServoAngleVisibleConverter : IMultiValueConverter
     {
         public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
         {
             if (values[0] is Device device)
             {
-                return values[1] is int channel && device.CanChangeMaxServoAngle(channel);
+                return values[1] is ChannelOutputType outputType && outputType == ChannelOutputType.ServoMotor &&
+                    values[2] is int channel && device.CanChangeMaxServoAngle(channel);
             }
 
             return false;

--- a/BrickController2/BrickController2/UI/Pages/ControllerActionPage.xaml
+++ b/BrickController2/BrickController2/UI/Pages/ControllerActionPage.xaml
@@ -17,11 +17,11 @@
     <local:PageBase.Resources>
         <ResourceDictionary>
             <converters:DeviceAndChannelToChannelOutputTypeVisibleConverter x:Key="DeviceAndChannelToChannelOutputTypeVisible"/>
-            <converters:DeviceAndChannelToMaxServoAngleVisibleConverter x:Key="DeviceAndChannelToMaxServoAngleVisible"/>
+			<converters:DeviceAndChannelOutputTypeToMaxServoAngleVisibleConverter x:Key="DeviceAndChannelOutputTypeToMaxServoAngleVisible"/>
         </ResourceDictionary>
     </local:PageBase.Resources>
 
-    <NavigationPage.TitleView>
+	<NavigationPage.TitleView>
         <Grid HorizontalOptions="FillAndExpand">
             <Label Text="{extensions:Translate ControllerAction}" TextColor="{DynamicResource NavigationBarItemColor}" FontSize="Medium" FontAttributes="Bold" HorizontalOptions="Start" VerticalOptions="Center"/>
             <controls:ImageButton ImageSource="{extensions:ImageResource Source=ic_checkmark.png}" Command="{Binding SaveControllerActionCommand}" Style="{StaticResource NavigationBarImageButtonStyle}" HorizontalOptions="End" Margin="12,0"/>
@@ -106,8 +106,9 @@
                             <!-- Max servo angle setting -->
                             <Grid ColumnSpacing="6" Margin="0,10">
                                 <Grid.IsVisible>
-                                    <MultiBinding Converter="{StaticResource DeviceAndChannelToMaxServoAngleVisible}">
+                                    <MultiBinding Converter="{StaticResource DeviceAndChannelOutputTypeToMaxServoAngleVisible}">
                                         <Binding Path="SelectedDevice" />
+										<Binding Path="Action.ChannelOutputType" />
                                         <Binding Path="Action.Channel" />
                                     </MultiBinding>
                                 </Grid.IsVisible>
@@ -125,7 +126,7 @@
                             </Grid>
 
                             <!-- Stepper angle setting -->
-                            <VerticalStackLayout IsVisible="False">
+                            <VerticalStackLayout IsVisible="False" Margin="0,10">
                                 <VerticalStackLayout.Triggers>
                                     <DataTrigger TargetType="VerticalStackLayout" Binding="{Binding Action.ChannelOutputType}" Value="{x:Static creationManagement:ChannelOutputType.StepperMotor}">
                                         <Setter Property="IsVisible" Value="True"/>


### PR DESCRIPTION
Seems (maybe due to MAUI transition) it's shown for `Normal` or `Stepper` output types as well, but IMHO should be hidden.

![image](https://github.com/user-attachments/assets/dc62a094-e479-45c8-9e7b-d64bc3223eff)
