### PR TITLE
[security] Use latest Newtonsoft.Json

### DIFF
--- a/BrickController2/BrickController2/BrickController2.csproj
+++ b/BrickController2/BrickController2/BrickController2.csproj
@@ -55,6 +55,7 @@
     <PackageReference Include="Microsoft.Maui.Controls" />
     <PackageReference Include="Microsoft.Maui.Controls.Compatibility" />
     <PackageReference Include="Microsoft.Maui.Essentials" />
+    <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="sqlite-net-pcl" />
     <PackageReference Include="SQLiteNetExtensions" />
     <PackageReference Include="SQLiteNetExtensions.Async" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,6 +8,7 @@
     <PackageVersion Include="Microsoft.Maui.Controls" Version="8.0.40" />
     <PackageVersion Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.40" />
     <PackageVersion Include="Microsoft.Maui.Essentials" Version="8.0.40" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="sqlite-net-pcl" Version="1.9.172" />
     <PackageVersion Include="SQLiteNetExtensions" Version="2.1.0" />
     <PackageVersion Include="SQLiteNetExtensions.Async" Version="2.1.0" />


### PR DESCRIPTION
I've noticed that `Newtonsoft.Json` version 9.0.1 , which is transitive dependency of [SQLiteNetExtensions](https://www.nuget.org/packages/SQLiteNetExtensions/2.1.0#dependencies-body-tab), is reported as vulnerable. Therefore I've directly overriden version used. For details see: https://github.com/advisories/GHSA-5crp-9r3c-p9vr
```
    D:\Source\BrickController\BrickController2\BrickController2\BrickController2.csproj : warning NU1903: Package 'Newtonsoft.Json' 9.0.1 has a known high severity vulnerability, https://github.com/advisories/GHSA-5crp-9r3c-p9vr
```