### PR TITLE
[iOS] Fix detection of devices via Service UUID (CircuitCubes, WeDo2)

### DIFF
--- a/BrickController2/BrickController2/DeviceManagement/BluetoothDeviceManager.cs
+++ b/BrickController2/BrickController2/DeviceManagement/BluetoothDeviceManager.cs
@@ -6,6 +6,8 @@ using System.Threading.Tasks;
 using BrickController2.Helpers;
 using BrickController2.PlatformServices.BluetoothLE;
 
+using static BrickController2.Protocols.BluetoothLowEnergy;
+
 namespace BrickController2.DeviceManagement
 {
     internal class BluetoothDeviceManager : IBluetoothDeviceManager
@@ -61,7 +63,7 @@ namespace BrickController2.DeviceManagement
                 return (DeviceType.Unknown, null);
             }
 
-            if (!advertismentData.TryGetValue(0xFF, out var manufacturerData) || manufacturerData.Length < 2)
+            if (!advertismentData.TryGetValue(ADTYPE_MANUFACTURER_SPECIFIC, out var manufacturerData) || manufacturerData.Length < 2)
             {
                 return GetDeviceInfoByService(advertismentData);
             }
@@ -74,7 +76,7 @@ namespace BrickController2.DeviceManagement
                 case "98-01": return (DeviceType.SBrick, manufacturerData);
                 case "48-4d": return (DeviceType.BuWizz, manufacturerData);
                 case "4e-05":
-                    if (advertismentData.TryGetValue(0x09, out byte[]? completeLocalName))
+                    if (advertismentData.TryGetValue(ADTYPE_LOCAL_NAME_COMPLETE, out byte[]? completeLocalName))
                     {
                         var completeLocalNameString = BitConverter.ToString(completeLocalName).ToLower();
                         if (completeLocalNameString == "42-75-57-69-7a-7a") // BuWizz
@@ -108,7 +110,7 @@ namespace BrickController2.DeviceManagement
         private (DeviceType DeviceType, byte[]? ManufacturerData) GetDeviceInfoByService(IDictionary<byte, byte[]> advertismentData)
         {
             // 0x06: 128 bits Service UUID type
-            if (!advertismentData.TryGetValue(0x06, out byte[]? serviceData) || serviceData.Length < 16)
+            if (!advertismentData.TryGetValue(ADTYPE_SERVICE_128BIT, out byte[]? serviceData) || serviceData.Length < 16)
             {
                 return (DeviceType.Unknown, null);
             }

--- a/BrickController2/BrickController2/DeviceManagement/CircuitCubeDevice.cs
+++ b/BrickController2/BrickController2/DeviceManagement/CircuitCubeDevice.cs
@@ -187,7 +187,7 @@ namespace BrickController2.DeviceManagement
                     commendBytes.CopyTo(_driveMotorsBuffer, idx);
                     idx += 5;
                 }
-                return await _bleDevice!.WriteAsync(_writeCharacteristic!, _driveMotorsBuffer, token);
+                return await _bleDevice!.WriteNoResponseAsync(_writeCharacteristic!, _driveMotorsBuffer, token);
             }
             catch (Exception)
             {
@@ -199,7 +199,7 @@ namespace BrickController2.DeviceManagement
         {
             try
             {
-                return await _bleDevice!.WriteAsync(_writeCharacteristic!, TURN_OFF_ALL_COMMAND, token);
+                return await _bleDevice!.WriteNoResponseAsync(_writeCharacteristic!, TURN_OFF_ALL_COMMAND, token);
             }
             catch (Exception)
             {
@@ -223,7 +223,7 @@ namespace BrickController2.DeviceManagement
                 HardwareVersion = hardwareRevision;
             }
 
-            await _bleDevice!.WriteAsync(_writeCharacteristic!, BATTERY_STATUS_COMMAND, token);
+            await _bleDevice!.WriteNoResponseAsync(_writeCharacteristic!, BATTERY_STATUS_COMMAND, token);
         }
     }
 }

--- a/BrickController2/BrickController2/Protocols/BluetoothLowEnergy.cs
+++ b/BrickController2/BrickController2/Protocols/BluetoothLowEnergy.cs
@@ -1,0 +1,9 @@
+﻿namespace BrickController2.Protocols;
+
+public static class BluetoothLowEnergy
+{
+    // advertisment data types
+    public const byte ADTYPE_SERVICE_128BIT = 0x06;        // Service: Additional 128-bit UUIDs
+    public const byte ADTYPE_LOCAL_NAME_COMPLETE = 0x09;   // Complete local name
+    public const byte ADTYPE_MANUFACTURER_SPECIFIC = 0xFF; // Manufacturer specific data
+}


### PR DESCRIPTION
Added processing of 0x06 advertisment data type so as devices such as CircuitCubes and WeDo2 are properly discovered by scanning.
Additionally there seemed to be issue with characteristics writes on iOS for Circuit Cubes:
- no batery level was read
- no output was applied for a channel

Obviously iOS is sensitive if write type does not match the one defined by a characteristic being written. So changed to `WriteNoResponseAsync` and it seems to be working on iOS, Android and Windows.

Resolves: #134
Seems to be related to #114 as well.