### PR TITLE
Fix detection of BuWizz2 having firmware 1.2.30

### DIFF
--- a/BrickController2/BrickController2/DeviceManagement/BluetoothDeviceManager.cs
+++ b/BrickController2/BrickController2/DeviceManagement/BluetoothDeviceManager.cs
@@ -88,7 +88,7 @@ namespace BrickController2.DeviceManagement
                     }
                     break;
                 case "05-45": // BuWizz2 has new ID since firmware 1.2.30
-                    if (advertismentData.TryGetValue(ADTYPE_LOCAL_NAME_COMPLETE, out byte[]? buwizzName))
+                    if (advertismentData.TryGetValue(0x09, out byte[]? buwizzName))
                     {
                         var completeLocalNameString = BitConverter.ToString(buwizzName).ToLower();
                         if (completeLocalNameString == "42-75-57-69-7a-7a-32") // BuWizz2

--- a/BrickController2/BrickController2/DeviceManagement/BluetoothDeviceManager.cs
+++ b/BrickController2/BrickController2/DeviceManagement/BluetoothDeviceManager.cs
@@ -74,27 +74,19 @@ namespace BrickController2.DeviceManagement
                 case "98-01": return (DeviceType.SBrick, manufacturerData);
                 case "48-4d": return (DeviceType.BuWizz, manufacturerData);
                 case "4e-05":
-                    if (advertismentData.TryGetValue(0x09, out byte[]? completeLocalName))
+                    // detect using manufacterer data prefix
+                    if (!manufacturerDataString.StartsWith("4e-05-42-57-03-"))
                     {
-                        var completeLocalNameString = BitConverter.ToString(completeLocalName).ToLower();
-                        if (completeLocalNameString == "42-75-57-69-7a-7a") // BuWizz
-                        {
-                            return (DeviceType.BuWizz2, manufacturerData);
-                        }
-                        else
-                        {
-                            return (DeviceType.BuWizz3, manufacturerData);
-                        }
+                        return (DeviceType.BuWizz2, manufacturerData);
                     }
-                    break;
-                case "05-45": // BuWizz2 has new ID since firmware 1.2.30
-                    if (advertismentData.TryGetValue(0x09, out byte[]? buwizzName))
+                    else
                     {
-                        var completeLocalNameString = BitConverter.ToString(buwizzName).ToLower();
-                        if (completeLocalNameString == "42-75-57-69-7a-7a-32") // BuWizz2
-                        {
-                            return (DeviceType.BuWizz2, manufacturerData);
-                        }
+                        return (DeviceType.BuWizz3, manufacturerData);
+                    }
+                case "05-45": // BuWizz2 has new ID since firmware 1.2.30 - use BuWizz2 prefix
+                    if (manufacturerDataString.StartsWith("05-45-42-57-02-"))
+                    {
+                        return (DeviceType.BuWizz2, manufacturerData);
                     }
                     break;
                 case "97-03":

--- a/BrickController2/BrickController2/DeviceManagement/BluetoothDeviceManager.cs
+++ b/BrickController2/BrickController2/DeviceManagement/BluetoothDeviceManager.cs
@@ -87,6 +87,16 @@ namespace BrickController2.DeviceManagement
                         }
                     }
                     break;
+                case "05-45": // BuWizz2 has new ID since firmware 1.2.30
+                    if (advertismentData.TryGetValue(ADTYPE_LOCAL_NAME_COMPLETE, out byte[]? buwizzName))
+                    {
+                        var completeLocalNameString = BitConverter.ToString(buwizzName).ToLower();
+                        if (completeLocalNameString == "42-75-57-69-7a-7a-32") // BuWizz2
+                        {
+                            return (DeviceType.BuWizz2, manufacturerData);
+                        }
+                    }
+                    break;
                 case "97-03":
                     if (manufacturerDataString.Length >= 11)
                     {


### PR DESCRIPTION
Add handling of new manufacturer id and device name, both changed by firmware upgrade. But scanning now checks manufacturer prefix that contains firmware major version.
Additionally changed the check for BuWizz3 as well as it might be wrongly detected if renamed to `BuWizz`.

For details, see doc:
* https://buwizz.com/BuWizz_2.0_API_1.3_web.pdf
* https://buwizz.com/BuWizz_3.0_API_3.6_web.pdf

Resolves #142 
Resolves #147 